### PR TITLE
Support Python Django 3 & 4; updated readme.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,4 @@ fabric.properties
 # .idea/misc.xml
 # *.ipr
 .idea/
+*/db.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -165,21 +165,6 @@ $RECYCLE.BIN/
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/jsLibraryMappings.xml
-
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
 # Gradle:
 .idea/gradle.xml
 .idea/libraries
@@ -216,3 +201,5 @@ fabric.properties
 # *.ipr
 .idea/
 */db.sqlite3
+.DS_Store
+.vscode

--- a/mysite/api/urls.py
+++ b/mysite/api/urls.py
@@ -1,4 +1,7 @@
-from django.urls import re_path
+try:
+    from django.urls import re_path as re_path_url
+except ImportError:
+    from django.conf.urls import url as re_path_url
 
 from . import views
 
@@ -6,8 +9,8 @@ app_name = 'api'
 
 urlpatterns = [
     # ex: /api/users/12345
-    re_path(r'^users/(?P<user_id>\w+)', views.users, name='users'),
+    re_path_url(r'^users/(?P<user_id>\w+)', views.users, name='users'),
     # ex: /api/companies/67890
-    re_path(r'^companies/(?P<company_id>\w+)', views.companies, name='companies'),
+    re_path_url(r'^companies/(?P<company_id>\w+)', views.companies, name='companies'),
 
 ]

--- a/mysite/api/urls.py
+++ b/mysite/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
@@ -6,8 +6,8 @@ app_name = 'api'
 
 urlpatterns = [
     # ex: /api/users/12345
-    url(r'^users/(?P<user_id>\w+)', views.users, name='users'),
+    re_path(r'^users/(?P<user_id>\w+)', views.users, name='users'),
     # ex: /api/companies/67890
-    url(r'^companies/(?P<company_id>\w+)', views.companies, name='companies'),
+    re_path(r'^companies/(?P<company_id>\w+)', views.companies, name='companies'),
 
 ]

--- a/mysite/mysite/settings.py
+++ b/mysite/mysite/settings.py
@@ -188,3 +188,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 STATIC_URL = '/static/'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/mysite/mysite/settings.py
+++ b/mysite/mysite/settings.py
@@ -189,4 +189,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+# Auto Field
+# https://docs.djangoproject.com/en/4.0/ref/models/fields/
+
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/mysite/mysite/urls.py
+++ b/mysite/mysite/urls.py
@@ -10,10 +10,10 @@ Class-based views
     1. Add an import:  from other_app.views import Home
     2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    1. Import the include() function: from django.urls import re_path, include
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 from rest_framework import routers
 from apisection import views
@@ -23,9 +23,9 @@ router.register(r'users', views.UserViewSet)
 router.register(r'groups', views.GroupViewSet)
 
 urlpatterns = [
-    url(r'^polls/', include('polls.urls')),
-    url(r'^api/', include('api.urls')),
-    url(r'^admin/', admin.site.urls),
-    url(r'^', include(router.urls)),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    re_path(r'^polls/', include('polls.urls')),
+    re_path(r'^api/', include('api.urls')),
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^', include(router.urls)),
+    re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/mysite/mysite/urls.py
+++ b/mysite/mysite/urls.py
@@ -13,7 +13,10 @@ Including another URLconf
     1. Import the include() function: from django.urls import re_path, include
     2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
-from django.urls import include, re_path
+try:
+    from django.urls import include, re_path as re_path_url
+except ImportError:
+    from django.conf.urls import include, url as re_path_url
 from django.contrib import admin
 from rest_framework import routers
 from apisection import views
@@ -23,9 +26,9 @@ router.register(r'users', views.UserViewSet)
 router.register(r'groups', views.GroupViewSet)
 
 urlpatterns = [
-    re_path(r'^polls/', include('polls.urls')),
-    re_path(r'^api/', include('api.urls')),
-    re_path(r'^admin/', admin.site.urls),
-    re_path(r'^', include(router.urls)),
-    re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    re_path_url(r'^polls/', include('polls.urls')),
+    re_path_url(r'^api/', include('api.urls')),
+    re_path_url(r'^admin/', admin.site.urls),
+    re_path_url(r'^', include(router.urls)),
+    re_path_url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/mysite/polls/urls.py
+++ b/mysite/polls/urls.py
@@ -1,16 +1,19 @@
-from django.urls import re_path
+try:
+    from django.urls import re_path as re_path_url
+except ImportError:
+    from django.conf.urls import url as re_path_url
 
 from . import views
 
 app_name = 'polls'
 
 urlpatterns = [
-    re_path(r'^$', views.index, name='index'),
+    re_path_url(r'^$', views.index, name='index'),
     # ex: /polls/5/
-    re_path(r'^(?P<question_id>[0-9]+)/$', views.detail, name='detail'),
+    re_path_url(r'^(?P<question_id>[0-9]+)/$', views.detail, name='detail'),
     # ex: /polls/5/results/
-    re_path(r'^(?P<question_id>[0-9]+)/results/$', views.results, name='results'),
+    re_path_url(r'^(?P<question_id>[0-9]+)/results/$', views.results, name='results'),
     # ex: /polls/5/vote/
-    re_path(r'^(?P<question_id>[0-9]+)/vote/$', views.vote, name='vote'),
+    re_path_url(r'^(?P<question_id>[0-9]+)/vote/$', views.vote, name='vote'),
 
 ]

--- a/mysite/polls/urls.py
+++ b/mysite/polls/urls.py
@@ -1,16 +1,16 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 app_name = 'polls'
 
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
+    re_path(r'^$', views.index, name='index'),
     # ex: /polls/5/
-    url(r'^(?P<question_id>[0-9]+)/$', views.detail, name='detail'),
+    re_path(r'^(?P<question_id>[0-9]+)/$', views.detail, name='detail'),
     # ex: /polls/5/results/
-    url(r'^(?P<question_id>[0-9]+)/results/$', views.results, name='results'),
+    re_path(r'^(?P<question_id>[0-9]+)/results/$', views.results, name='results'),
     # ex: /polls/5/vote/
-    url(r'^(?P<question_id>[0-9]+)/vote/$', views.vote, name='vote'),
+    re_path(r'^(?P<question_id>[0-9]+)/vote/$', views.vote, name='vote'),
 
 ]

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Moesif Django Example
 
-Django is a web application framework that many developers to serve APIs.
+Django is a web application framework that many developers use to serve APIs.
 
 [Moesif](https://www.moesif.com) is an API analytics and monitoring platform. [moesifdjango](https://github.com/Moesif/moesifdjango)
 is a middleware that makes integration with Moesif easy for Django based applications.
@@ -17,31 +17,37 @@ the steps for setup Moesif Django. But here is the key file where the Moesif int
 
 ## How to run this example.
 
-1. Setup [virtual env](https://virtualenv.pypa.io/en/stable/) if needed `virtualenv ENV`. Start the virtual env by `source ENV/bin/activate`
+1. Setup [virtual env](https://docs.python.org/3.10/library/venv.html) if needed `python -m venv ENV`. Start the virtual env by `source ENV/bin/activate`
 
-2. Install packages. `pip install -r requirements.txt`
+2. Install packages:
+* Django 3 LTS: `pip install -r requirements.txt`  
+* Django 4: `pip install -r requirements-django4.txt`
 
-5. Be sure to edit the `mysite/setting.py` to add your Moesif application id.
+3. Be sure to edit the `mysite/setting.py` to add your Moesif application id.
 
   ```python
   MOESIF_MIDDLEWARE = {
-      'APPLICATION_ID': 'Your Moesif Application Id',
+      'APPLICATION_ID': 'Your Moesif Collector Application Id',
   }
   ```
   
-Your Moesif Application Id can be found in the [_Moesif Portal_](https://www.moesif.com/).
+Your Moesif Collector Application Id can be found in the [_Moesif Portal_](https://www.moesif.com/).
 After signing up for a Moesif account, your Moesif Application Id will be displayed during the onboarding steps. 
 
-You can always find your Moesif Application Id at any time by logging 
-into the [_Moesif Portal_](https://www.moesif.com/), click on the top right menu,
-and then clicking _Installation_.
+You can always find your Moesif Collector Application Id at any time by logging 
+into the [_Moesif Portal_](https://www.moesif.com/), click on the bottom left user profile,
+and then clicking _API Keys_.
 
-6. Run the service:
+4. Run the service:
 
 ```bash
 python manage.py runserver
 ```
 
-7. See `urls.py` for some urls that you can hit the server with
+5. See `urls.py` for some urls that you can hit the server with
 (e.g. `http://localhost:8000/users`), and the data
 should be captured in the corresponding Moesif account of the application id.
+
+
+Tested Python versions: `3.10.4`  
+Tested Django versions: `3.2.13 (LTS)`, `4.0.5`

--- a/requirements-django4.txt
+++ b/requirements-django4.txt
@@ -1,3 +1,3 @@
-Django==3.2.13
+Django==4.0.5
 moesifdjango==2.0.5
 djangorestframework==3.13.1


### PR DESCRIPTION
* Added support for Django version `3.2.13 LTS` and Django version `4.0.5`
* Tested on Python version `3.10.4`
* Updated `readme.md` to use Python `venv` and fixed instructions to find Moesif Application ID
* Removed 2 warnings
* Updated `.gitignore` for `db.sqlite3`